### PR TITLE
added tests for cd functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: rust
+rust: 1.2.0-nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: rust
-rust: 1.2.0-nightly
+rust:
+  - 1.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: rust
-rust:
-  - 1.2.0
+rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "splash"
 version = "0.0.1"
 
 [dependencies]
+regex = "0.1.8"
 getopts = "0.2"
 parser-combinators = "0.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@
 name = "splash"
 version = "0.0.1"
 
+[profile.dev]
+debug = true
+
 [dependencies]
 regex = "0.1.8"
 getopts = "0.2"

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -76,15 +76,17 @@ impl Builtin for Cd {
             .unwrap();
 
         let re = Regex::new("^~/(.*)").unwrap();
-        let caps = re.captures(&args[0]).unwrap();
-
-        if caps.len() != 0 {
-            if let Ok(home) = env::var("HOME") {
-                if home.len() != 0 {
-                    pwd_buf.push(home);
-                    pwd_buf.push(caps.at(1).unwrap());
+        if let Some(caps) = re.captures(&args[0]) {
+            if caps.len() != 0 {
+                if let Ok(home) = env::var("HOME") {
+                    if home.len() != 0 {
+                        pwd_buf.push(home);
+                        pwd_buf.push(caps.at(1).unwrap());
+                    }
                 }
             }
+        } else {
+            pwd_buf.push(&args[0]);
         }
 
         self.change_to(&pwd_buf).and(SUCCESS)

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -49,7 +49,7 @@ fn normalize_logical_path<P: AsRef<Path>>(path: &P) -> PathBuf {
 
 impl Builtin for Cd {
     fn run(&mut self, args: &[String]) -> io::Result<i32> {
-        if args.len() == 0 || args[0] == "~" {
+        if args.len() == 0 {
             if let Ok(home) = env::var("HOME") {
                 if home.len() != 0 {
                     return self.change_to(&PathBuf::from(&home))
@@ -155,18 +155,6 @@ mod tests {
 
         let mut cd = Cd::new();
         cd.run(&[]);
-
-        assert_eq!(env::var("PWD"), Ok(home));
-    }
-
-    #[test]
-    fn cd_with_tilde() {
-        let _g = LOCK.lock().unwrap();
-        let home = String::from("home");
-        env::set_var("HOME", &home);
-
-        let mut cd = Cd::new();
-        cd.run(&["~".to_string()]);
 
         assert_eq!(env::var("PWD"), Ok(home));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ mod prompt;
 mod parser;
 mod builtin;
 
+mod tests;
+
 fn main() {
     prompt::input_loop();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate readline;
 extern crate parser_combinators;
 extern crate getopts;
+extern crate regex;
 
 mod prompt;
 mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(std_misc)]
 extern crate readline;
 extern crate parser_combinators;
 extern crate getopts;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
 #![feature(std_misc)]
+
 extern crate readline;
 extern crate parser_combinators;
 extern crate getopts;
 extern crate regex;
 
+#[macro_use]
+mod tests;
+
 mod prompt;
 mod parser;
 mod builtin;
-
-mod tests;
 
 fn main() {
     prompt::input_loop();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,63 @@
+use std::thread;
+
+type EmptyFn = fn() -> ();
+type BeforeEachFn = fn() -> Vec<String>;
+
+pub struct TestFixture<'a> {
+    setup: Option<&'a EmptyFn>,
+    teardown: Option<&'a EmptyFn>,
+    before_each: Option<BeforeEachFn>,
+    after_each: Option<&'a EmptyFn>
+}
+
+impl<'a> TestFixture<'a> {
+    fn new() -> TestFixture<'a> {
+        TestFixture {
+            setup: None,
+            teardown: None,
+            before_each: None,
+            after_each: None,
+        }
+    }
+}
+
+pub trait TestFn {
+    fn run(&self, Vec<String>) -> ();
+}
+
+impl<F> TestFn for F
+    where F: Fn() -> () {
+    fn run(&self, args: Vec<String>) {
+        (*self)()
+    }
+}
+
+pub fn test_runner(tests: Vec<&TestFn>, fixture: TestFixture) {
+    if let Some(setup) = fixture.setup {
+        setup()
+    }
+
+    let before_each = match fixture.before_each {
+        Some(f) => f,
+        None => (|| { Vec::new() }) as fn() -> Vec<String>,
+    };
+
+    tests.iter().map(|&t| {
+        let before_each_copy = before_each.clone();
+        let handle = thread::spawn(move || {
+            t.run(before_each_copy());
+        });
+
+        if let Err(e) = handle.join() {
+            panic!(e);
+        }
+
+        if let Some(after_each) = fixture.after_each {
+            after_each();
+        }
+    });
+
+    if let Some(teardown) = fixture.teardown {
+        teardown();
+    }
+}


### PR DESCRIPTION
Added tests for:

* going to a root path
* going to a relative path
* going back with hyphen
* going home with no args

It needs synchronization because rust tests run in parallel and we are accessing and mutating a shared env variable. We need to think about testing because right now there is race condition between prompt's tests and these since both change PWD. We could put them all together and run serially or use some big global mutex, thoughts?

It conditionally changes the PWD in `change_to` because we can't assume that any fake directories we use in the tests exist on all machines, so we always set the PWD even if they don't so that tests pass. If not testing, then we should not change PWD since then it would throw an error that the directory is not found but still change the prompt directory.