### PR TITLE
Redirect to/from files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: rust
 
 rust: 1.6.0
 
-before_script: SPASH_BUILD_DIR=$TRAVIS_BUILD_DIR
+env:
+    - SPASH_BUILD_DIR=$TRAVIS_BUILD_DIR RUST_TEST_THREADS=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ version = "0.0.1"
 [profile.dev]
 debug = true
 
+[profile.test]
+debug = true
+
 [dependencies]
 combine = "^1.2"
 getopts = "^0.2"
@@ -15,3 +18,6 @@ lazy_static = "^0.1.15"
 libc = "*"
 nix = "^0.4.2"
 readline = "^0.0.11"
+
+[dev-dependencies]
+tempfile = "2.1.1"

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,3 @@
-use libc::{STDOUT_FILENO, STDIN_FILENO};
 use nix::unistd;
 use std::os::unix::io::{RawFd, AsRawFd};
 use std::fs::File;
@@ -7,26 +6,6 @@ use std::fs::File;
 pub enum Fd {
     Raw(Raw),
     File(File),
-}
-
-/// Reopen `fd` as stdin
-pub fn as_stdin(fd: &mut Fd) {
-    if fd.get_fd() == STDIN_FILENO {
-        return;
-    }
-
-    unistd::dup2(fd.get_fd(), STDIN_FILENO).unwrap();
-    fd.close();
-}
-
-/// Reopen `fd` as stdout
-pub fn as_stdout(fd: &mut Fd) {
-    if fd.get_fd() == STDOUT_FILENO {
-        return;
-    }
-
-    unistd::dup2(fd.get_fd(), STDOUT_FILENO).unwrap();
-    fd.close();
 }
 
 #[derive(Debug)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,103 @@
+use libc::{STDOUT_FILENO, STDIN_FILENO};
+use nix::unistd;
+use std::os::unix::io::{RawFd, AsRawFd};
+use std::fs::File;
+
+#[derive(Debug)]
+pub enum Fd {
+    Pipe(Pipe),
+    File(File),
+}
+
+/// Reopen `fd` as stdin
+pub fn as_stdin(fd: &mut Fd) {
+    if fd.get_fd() == STDIN_FILENO {
+        return;
+    }
+
+    unistd::dup2(fd.get_fd(), STDIN_FILENO).unwrap();
+    fd.close();
+}
+
+/// Reopen `fd` as stdout
+pub fn as_stdout(fd: &mut Fd) {
+    if fd.get_fd() == STDOUT_FILENO {
+        return;
+    }
+
+    unistd::dup2(fd.get_fd(), STDOUT_FILENO).unwrap();
+    fd.close();
+}
+
+#[derive(Debug)]
+pub struct Pipe {
+    fd: i32,
+    is_closed: bool,
+}
+
+impl Pipe {
+    pub fn new(fd: i32) -> Pipe {
+        Pipe {
+            fd: fd,
+            is_closed: false,
+        }
+    }
+
+    pub fn close(&mut self) {
+        if self.is_closed {
+            return;
+        }
+
+        unistd::close(self.fd).unwrap();
+        self.is_closed = true;
+    }
+}
+
+impl Drop for Pipe {
+    fn drop(&mut self) {
+        if self.fd > 2 && !self.is_closed {
+            self.close();
+        }
+    }
+}
+
+impl From<i32> for Pipe {
+    /// Actually duplicates the file descriptor
+    fn from(fd: i32) -> Pipe {
+        Pipe::new(unistd::dup(fd).unwrap())
+    }
+}
+
+impl Fd {
+    /// Wraps an existing `fd` in a pipe object
+    pub fn new_pipe(fd: i32) -> Fd {
+        Fd::Pipe(Pipe::new(fd))
+    }
+
+    pub fn get_fd(&self) -> RawFd {
+        match self {
+            &Fd::Pipe(ref p) => p.fd,
+            &Fd::File(ref f) => f.as_raw_fd(),
+        }
+    }
+
+    pub fn close(&mut self) {
+        match self {
+            &mut Fd::Pipe(ref mut p) => p.close(),
+            // no-op since files automatically closed
+            &mut Fd::File(..) => {},
+        }
+    }
+}
+
+impl From<File> for Fd {
+    fn from(f: File) -> Fd {
+        Fd::File(f)
+    }
+}
+
+impl From<i32> for Fd {
+    fn from(fd: i32) -> Fd {
+        Fd::Pipe(Pipe::from(fd))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod lexer;
 mod process;
 mod prompt;
 mod tokenizer;
+mod file;
 
 use getopts::Options;
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -9,6 +9,7 @@ use std::ffi::CString;
 use std::io::{self, Write};
 use nix::unistd::isatty;
 use std::process::exit;
+use util::write_err;
 
 static WAVE_EMOJI: &'static str = "\u{1F30A}";
 
@@ -37,7 +38,7 @@ pub fn input_loop() {
 
         match execute(&mut builtins, &mut user_env, command.unwrap()) {
             Err(e) => {
-                writeln!(stderr.lock(), "An error occured: {}", e).unwrap();
+                write_err(&format!("splash: {}", e));
             },
             Ok(n) => {
                 last_status = n;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -8,6 +8,8 @@ pub enum AST {
     Var(String),
     Eql,
     Pipe,
+    LT,
+    GT
 }
 
 impl Display for AST {
@@ -93,6 +95,14 @@ fn eql_tok(reader: &mut CharReader) -> ASTResult {
 
 fn pipe_tok(reader: &mut CharReader) -> ASTResult {
     char_tok(reader, '|', AST::Pipe)
+}
+
+fn redir_in_tok(reader: &mut CharReader) -> ASTResult {
+    char_tok(reader, '<', AST::LT)
+}
+
+fn redir_out_tok(reader: &mut CharReader) -> ASTResult {
+    char_tok(reader, '>', AST::GT)
 }
 
 fn escaped_tok(reader: &mut CharReader) -> ASTResult {
@@ -222,7 +232,9 @@ pub fn tokenize(s: &str) -> Result<Vec<AST>, String> {
         quotemark_tok,
         var_tok,
         eql_tok,
-        pipe_tok);
+        pipe_tok,
+        redir_in_tok,
+        redir_out_tok);
 
     tokenize_loop(&mut reader, tokenizers, |reader| reader.current)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,20 @@ macro_rules! is_match {
     ))
 }
 
+// from http://stackoverflow.com/a/27582993
+#[export_macro]
+macro_rules! hash_map(
+    { $($key:expr => $value:expr,)+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+     };
+);
+
 #[inline]
 pub fn write_err(s: String) {
     let stderr = io::stderr();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use std::io::{self, Write};
+use std::fmt::Display;
 
 #[export_macro]
 macro_rules! is_match {
@@ -22,7 +23,7 @@ macro_rules! hash_map(
 );
 
 #[inline]
-pub fn write_err(s: String) {
+pub fn write_err<D: Display>(s: &D) {
     let stderr = io::stderr();
     let res = writeln!(stderr.lock(), "{}", s);
     res.unwrap();

--- a/tests/process_tests.rs
+++ b/tests/process_tests.rs
@@ -1,8 +1,11 @@
-use std::process::Command;
 use std::env;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::process::Command;
 
 fn run_command(cmd: &str) -> (i32, String) {
     let build_dir = env::var("SPLASH_BUILD_DIR").unwrap_or(String::from("target/debug"));
+
     let output = Command::new("sh")
                      .arg("-c")
                      .arg(format!("echo \"{}\" | splash", cmd))
@@ -75,4 +78,45 @@ fn command_not_found() {
     let (ecode, output) = run_command("not_a_program");
     assert_eq!(ecode, 127);
     assert_eq!(output, String::from(""));
+}
+
+#[test]
+fn redirect_out() {
+    let (ecode, output) = run_command("echo 'foo' > foo_out.txt");
+
+    assert_eq!(ecode, 0);
+    assert_eq!(output, String::from(""));
+
+    let mut f = File::open("foo_out.txt").unwrap();
+    let mut contents = String::new();
+    f.read_to_string(&mut contents).unwrap();
+    assert_eq!(contents, "foo\n");
+
+    fs::remove_file("foo_out.txt").unwrap();
+}
+
+#[test]
+fn redirect_in() {
+    let mut f = File::create("foo_in.txt").unwrap();
+    f.write(b"hello\n").unwrap();
+    f.flush().unwrap();
+
+    let (ecode, output) = run_command("cat < foo_in.txt");
+    fs::remove_file("foo_in.txt").unwrap();
+
+    assert_eq!(ecode, 0);
+    assert_eq!(output, String::from("hello\n"));
+}
+
+#[test]
+fn redirect_overrides_pipe() {
+    let mut f = File::create("foo_in.txt").unwrap();
+    f.write(b"hello\n").unwrap();
+    f.flush().unwrap();
+
+    let (ecode, output) = run_command("echo 'hi' | cat < foo_in.txt");
+    fs::remove_file("foo_in.txt").unwrap();
+
+    assert_eq!(ecode, 0);
+    assert_eq!(output, String::from("hello\n"));
 }

--- a/tests/process_tests.rs
+++ b/tests/process_tests.rs
@@ -130,3 +130,17 @@ fn redirect_in_other_fd() {
     assert_eq!(output, String::from("hello\n"));
     assert_eq!(ecode, 0);
 }
+
+#[test]
+fn redirect_out_other_fd() {
+    let mut f = NamedTempFile::new().unwrap();
+
+    let (ecode, output) = run_command(format!("echo 'hello' | cat 3> {} >&3", f.path().display()));
+
+    assert_eq!(output, String::new());
+    assert_eq!(ecode, 0);
+
+    let mut contents = String::new();
+    f.read_to_string(&mut contents).unwrap();
+    assert_eq!(contents, "hello\n");
+}

--- a/tests/process_tests.rs
+++ b/tests/process_tests.rs
@@ -18,13 +18,6 @@ fn run_command(cmd: &str) -> (i32, String) {
 }
 
 #[test]
-fn foo() {
-    let (ecode, output) = run_command("pwd");
-    println!("ecode: {}", ecode);
-    println!("output: {}", output);
-}
-
-#[test]
 fn run_builtin() {
     let (ecode, output) = run_command("echo hello");
     assert_eq!(ecode, 0);


### PR DESCRIPTION
Fixes #11. Still to do
- [x] allow numeric prefixes for redirects
- [x] allow for redirects before and after the command
- [x] generalize file descriptors
- [x] error handling for files
- [x] allow `<>` (maybe)
